### PR TITLE
works great on the first shot. Thanks AI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "nuxt.isNuxtApp": false
 }

--- a/android/.project
+++ b/android/.project
@@ -6,12 +6,18 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 	<filteredResources>

--- a/android/src/main/java/co/broadcastapp/muckabout/RemoteStreamerPlugin.java
+++ b/android/src/main/java/co/broadcastapp/muckabout/RemoteStreamerPlugin.java
@@ -15,8 +15,7 @@ import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
-import android.support.v4.media.session.MediaSessionCompat;
-import android.support.v4.media.session.PlaybackStateCompat;
+
 import android.util.Log;
 
 import androidx.core.content.ContextCompat;
@@ -26,38 +25,18 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.PlaybackException;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.ProgressiveMediaSource;
-import com.google.android.exoplayer2.source.hls.HlsMediaSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
-
-import org.json.JSONException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.json.JSONException;
+import java.io.IOException;
+import java.net.URL;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.io.InputStream;
 
 @CapacitorPlugin(name = "RemoteStreamer")
-public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudioFocusChangeListener {
-    private ExoPlayer player;
-    private DefaultDataSource.Factory dataSourceFactory;
-    private AudioManager audioManager;
-    private AudioFocusRequest focusRequest;
-    private Handler handler;
-    private Runnable updateTimeTask;
+public class RemoteStreamerPlugin extends Plugin {
     private boolean isLiveStream = false;
-
-    private MediaSessionCompat mediaSession;
     private RemoteStreamerService service = null;
 
     private final ServiceConnection serviceConnection = new ServiceConnection() {
@@ -67,7 +46,6 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
             service = binder.getService();
             Intent intent = new Intent(getActivity(), getActivity().getClass());
             service.connectAndInitialize(RemoteStreamerPlugin.this, intent);
-            startMediaService();
         }
 
         @Override
@@ -80,34 +58,6 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     @Override
     public void load() {
         super.load();
-        Context context = getContext();
-        handler = new Handler(Looper.getMainLooper());
-        audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        String versionName = "1.0"; // Default version
-        String deviceModel = android.os.Build.MODEL;
-        String osVersion = android.os.Build.VERSION.RELEASE;
-        try {
-            versionName = context.getPackageManager()
-            .getPackageInfo(context.getPackageName(), 0).versionName;
-        } catch (Exception e) {
-            Log.e("RemoteStreamerPlugin", "Failed to get version name", e);
-        }
-        String userAgent = "WNYC-App/" + versionName + " (Android " + osVersion + "; " + deviceModel + ")";
-        DefaultHttpDataSource.Factory httpDataSourceFactory =
-            new DefaultHttpDataSource.Factory().setUserAgent(userAgent);
-        dataSourceFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);
-        mediaSession = new MediaSessionCompat(context, "wnyc");
-
-        AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_MEDIA)
-                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                .build();
-
-        focusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-                .setAudioAttributes(audioAttributes)
-                .setAcceptsDelayedFocusGain(true)
-                .setOnAudioFocusChangeListener(this)
-                .build();
     }
 
     public void startMediaService() {
@@ -127,92 +77,28 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
 
         if (service == null) {
             startMediaService();
-            while (service == null) {
+            // Wait for service to connect? Ideally we should queue the command or wait.
+            // The original code waited with sleep loop.
+            int retries = 0;
+            while (service == null && retries < 20) {
                 try {
                     Thread.sleep(100);
+                    retries++;
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
             }
         }
 
-        handler.post(() -> {
-            releasePlayer();
-            player = new ExoPlayer.Builder(getContext()).build();
-
-            MediaSource mediaSource;
-            if (url.contains(".m3u8")) {
-                mediaSource = new HlsMediaSource.Factory(dataSourceFactory)
-                        .createMediaSource(MediaItem.fromUri(url));
-                this.isLiveStream = true;
-                service.setDuration(0);
-                service.setPosition(0);
-            } else {
-                mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory)
-                        .createMediaSource(MediaItem.fromUri(url));
-                this.isLiveStream = false;
-            }
-
-            player.setMediaSource(mediaSource);
-            player.prepare();
-
-            setupPlayerListeners();
-
-            int focusResult = audioManager.requestAudioFocus(focusRequest);
-            if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                player.play();
-            }
-            Log.d("stream", "playing");
-            service.setPlaybackState(PlaybackStateCompat.STATE_PLAYING);
-            service.update();
-
-            notifyListeners("play", new JSObject());
+        if (service != null) {
+            service.play(url);
             call.resolve();
-        });
+        } else {
+            call.reject("Service failed to start");
+        }
     }
 
-    private void setupPlayerListeners() {
-        player.addListener(new Player.Listener() {
-            @Override
-            public void onPlaybackStateChanged(int state) {
-                switch (state) {
-                    case Player.STATE_BUFFERING:
-                        notifyListeners("buffering", new JSObject().put("isBuffering", true));
-                        break;
-                    case Player.STATE_READY:
-                        notifyListeners("buffering", new JSObject().put("isBuffering", false));
-                        if (!isLiveStream) startUpdatingTime();
-                        break;
-                    case Player.STATE_ENDED:
-                        stopUpdatingTime();
-                        stop(true);
-                        break;
-                }
-            }
 
-            @Override
-            public void onIsPlayingChanged(boolean isPlaying) {
-                if (isPlaying) {
-                    notifyListeners("play", new JSObject());
-                } else {
-                    notifyListeners("pause", new JSObject());
-                }
-            }
-
-            @Override
-            public void onPlayerError(PlaybackException error) {
-                if (error.getCause().getClass().equals(java.net.ConnectException.class)) {
-                    pause();
-                }
-                if (error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW) {
-                    player.seekToDefaultPosition();
-                    player.prepare();
-                    player.play();
-                }
-                notifyListeners("error", new JSObject().put("message", error.getMessage()));
-            }
-        });
-    }
 
     @PluginMethod
     public void pause(PluginCall call) {
@@ -221,16 +107,8 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     }
 
     private void pause() {
-        if (player != null) {
-            Log.d("RemoteStreamerPlugin", "pausing playback");
-            handler.post(() -> {
-                service.setPlaybackState(PlaybackStateCompat.STATE_PAUSED);
-                service.update();
-                if (player != null) {
-                    player.pause();
-                }
-            });
-            notifyListeners("pause", new JSObject());
+        if (service != null) {
+            service.pause();
         }
     }
 
@@ -241,23 +119,8 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     }
 
     private void resume() {
-        if (player != null) {
-            Log.d("RemoteStreamerPlugin", "resuming playback");
-            int focusResult = audioManager.requestAudioFocus(focusRequest);
-            if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                handler.post(() -> {
-                    if (player != null) {
-                        if (isLiveStream) {
-                            // if a live stream is paused and resumed, catch up to live
-                            player.seekToDefaultPosition();
-                        }
-                        player.play();
-                    }
-                });
-                service.setPlaybackState(PlaybackStateCompat.STATE_PLAYING);
-                service.update();
-                notifyListeners("play", new JSObject());
-            }
+        if (service != null) {
+            service.resume();
         }
     }
 
@@ -275,8 +138,8 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     }
 
     private void seekTo(Long position) {
-        if (player != null) {
-            handler.post(() -> player.seekTo(position));
+        if (service != null) {
+            service.seekTo(position);
         }
     }
 
@@ -291,11 +154,8 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     }
 
     public void stop(final boolean ended) {
-        notifyListeners("stop", new JSObject().put("ended", ended));
-        releasePlayer();
         if (service != null) {
-            // stop may be called before the service is started
-            service.destroy();
+            service.stop(ended);
         }
     }
 
@@ -343,95 +203,32 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
     }
 
     private void releasePlayer() {
-        if (player != null) {
-            handler.post(() -> {
-                Log.d("RemoteStreamerPlugin", "releaseing player");
-                stopUpdatingTime();
-                if (player != null) {
-                        player.release();
-                        player = null;
-                }   
-                audioManager.abandonAudioFocusRequest(focusRequest);
-            });
+        if (service != null) {
+            service.releasePlayer();
         }
     }
 
-    private void startUpdatingTime() {
-        stopUpdatingTime();
-        updateTimeTask = new Runnable() {
-            @Override
-            public void run() {
-                if (player != null && player.isPlaying()) {
-                    long currentTime = player.getCurrentPosition();
-                    long duration = player.getDuration();
-                    service.setDuration(duration);
-                    service.setPosition(currentTime);
-                    service.update();
-                    JSObject timeData = new JSObject()
-                            .put("currentTime", currentTime / 1000.0)
-                            .put("duration", duration == C.TIME_UNSET ? 0 : duration / 1000.0);
-                    notifyListeners("timeUpdate", timeData);
-                    handler.postDelayed(this, 500);
-                } else {
-                    handler.postDelayed(this, 1000);
-                }
-            }
-        };
-        handler.post(updateTimeTask);
-    }
 
-    private void stopUpdatingTime() {
-        if (updateTimeTask != null) {
-            handler.removeCallbacks(updateTimeTask);
-            updateTimeTask = null;
-        }
-    }
 
     @Override
     protected void handleOnDestroy() {
-        releasePlayer();
+        // Do not stop player here to allow background playback
         super.handleOnDestroy();
     }
 
-    private boolean resumeOnFocusLossTransient = false;
 
-    @Override
-    public void onAudioFocusChange(int focusChange) {
-        if (player == null) {
-            return;
-        }
-
-        handler.post(() -> {
-            switch (focusChange) {
-                case AudioManager.AUDIOFOCUS_GAIN:
-                    player.setVolume(1.0f);
-                    if (resumeOnFocusLossTransient) {
-                        player.play();
-                    }
-                    break;
-                case AudioManager.AUDIOFOCUS_LOSS:
-                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                    resumeOnFocusLossTransient = player.isPlaying();
-                    player.pause();
-                    break;
-                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                    player.setVolume(0.1f);
-                    break;
-            }
-        });
-    }
 
     @PluginMethod
     public void setVolume(PluginCall call) {
-        handler.post(() -> {
-            Float volume;
-            try {
-                volume = (float) call.getData().getDouble("volume");
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
-            player.setVolume(volume);
-        });
+        Float volume;
+        try {
+            volume = (float) call.getData().getDouble("volume");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        if (service != null) {
+            service.setVolume(volume);
+        }
     }
 
     public void actionCallback(String action) {
@@ -449,11 +246,15 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
                 break;
 
             case "nexttrack":
-                seekTo(player.getCurrentPosition() + 10000);
+                if (service != null) {
+                    seekTo(service.getCurrentPosition() + 10000);
+                }
                 break;
 
             case "previoustrack":
-                seekTo(player.getCurrentPosition() - 10000);
+                if (service != null) {
+                    seekTo(service.getCurrentPosition() - 10000);
+                }
                 break;
 
             case "seekto":
@@ -465,6 +266,10 @@ public class RemoteStreamerPlugin extends Plugin implements AudioManager.OnAudio
                 }
                 break;
         }
+    }
+
+    public void onPlayerEvent(String event, JSObject data) {
+        notifyListeners(event, data);
     }
 
     private final Set<String> lsactions = Set.of("pause", "play");

--- a/android/src/main/java/co/broadcastapp/muckabout/RemoteStreamerService.java
+++ b/android/src/main/java/co/broadcastapp/muckabout/RemoteStreamerService.java
@@ -6,6 +6,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
@@ -30,7 +31,28 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-    public class RemoteStreamerService extends Service {
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.PlaybackException;
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
+import com.google.android.exoplayer2.source.hls.HlsMediaSource;
+import com.google.android.exoplayer2.upstream.DefaultDataSource;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import com.getcapacitor.JSObject;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.io.IOException;
+import java.io.InputStream;
+import android.graphics.BitmapFactory;
+
+    public class RemoteStreamerService extends Service implements AudioManager.OnAudioFocusChangeListener {
         private static final String TAG = "RemoteStreamerService";
 
         private MediaSessionCompat mediaSession;
@@ -59,6 +81,15 @@ import java.util.Set;
         private boolean mediaMetadataUpdate = false;
         private boolean notificationUpdate = false;
 
+        private ExoPlayer player;
+        private DefaultDataSource.Factory dataSourceFactory;
+        private AudioManager audioManager;
+        private AudioFocusRequest focusRequest;
+        private Handler handler;
+        private Runnable updateTimeTask;
+        private boolean isLiveStream = false;
+        private boolean resumeOnFocusLossTransient = false;
+
         private RemoteStreamerPlugin plugin;
 
         private final IBinder binder = new LocalBinder();
@@ -67,6 +98,38 @@ import java.util.Set;
             public RemoteStreamerService getService() {
                 return RemoteStreamerService.this;
             }
+        }
+
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            handler = new Handler(Looper.getMainLooper());
+            audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+            
+            String versionName = "1.0"; // Default version
+            String deviceModel = android.os.Build.MODEL;
+            String osVersion = android.os.Build.VERSION.RELEASE;
+            try {
+                versionName = getPackageManager()
+                .getPackageInfo(getPackageName(), 0).versionName;
+            } catch (Exception e) {
+                Log.e("RemoteStreamerService", "Failed to get version name", e);
+            }
+            String userAgent = "WNYC-App/" + versionName + " (Android " + osVersion + "; " + deviceModel + ")";
+            DefaultHttpDataSource.Factory httpDataSourceFactory =
+                new DefaultHttpDataSource.Factory().setUserAgent(userAgent);
+            dataSourceFactory = new DefaultDataSource.Factory(this, httpDataSourceFactory);
+
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .build();
+
+            focusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                    .setAudioAttributes(audioAttributes)
+                    .setAcceptsDelayedFocusGain(true)
+                    .setOnAudioFocusChangeListener(this)
+                    .build();
         }
 
         @Override
@@ -149,6 +212,7 @@ import java.util.Set;
         }
 
         public void destroy() {
+            releasePlayer();
             stopForeground(true);
             //mediaSession.setActive(false);
             notificationManager.cancel(NOTIFICATION_ID);
@@ -304,5 +368,225 @@ import java.util.Set;
         public void updatePossibleActions() {
             this.possibleActionsUpdate = true;
             this.update();
+        }
+
+        public void play(String url) {
+            if (url == null) return;
+
+            handler.post(() -> {
+                releasePlayer();
+                player = new ExoPlayer.Builder(this).build();
+
+                MediaSource mediaSource;
+                if (url.contains(".m3u8")) {
+                    mediaSource = new HlsMediaSource.Factory(dataSourceFactory)
+                            .createMediaSource(MediaItem.fromUri(url));
+                    this.isLiveStream = true;
+                    setDuration(0);
+                    setPosition(0);
+                } else {
+                    mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory)
+                            .createMediaSource(MediaItem.fromUri(url));
+                    this.isLiveStream = false;
+                }
+
+                player.setMediaSource(mediaSource);
+                player.prepare();
+
+                setupPlayerListeners();
+
+                int focusResult = audioManager.requestAudioFocus(focusRequest);
+                if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+                    player.play();
+                }
+                Log.d("stream", "playing");
+                setPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+                update();
+
+                if (plugin != null) plugin.onPlayerEvent("play", new JSObject());
+            });
+        }
+
+        public void pause() {
+            if (player != null) {
+                Log.d("RemoteStreamerService", "pausing playback");
+                handler.post(() -> {
+                    setPlaybackState(PlaybackStateCompat.STATE_PAUSED);
+                    update();
+                    if (player != null) {
+                        player.pause();
+                    }
+                });
+                if (plugin != null) plugin.onPlayerEvent("pause", new JSObject());
+            }
+        }
+
+        public void resume() {
+            if (player != null) {
+                Log.d("RemoteStreamerService", "resuming playback");
+                int focusResult = audioManager.requestAudioFocus(focusRequest);
+                if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+                    handler.post(() -> {
+                        if (player != null) {
+                            if (isLiveStream) {
+                                // if a live stream is paused and resumed, catch up to live
+                                player.seekToDefaultPosition();
+                            }
+                            player.play();
+                        }
+                    });
+                    setPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+                    update();
+                    if (plugin != null) plugin.onPlayerEvent("play", new JSObject());
+                }
+            }
+        }
+
+        public void seekTo(Long position) {
+            if (player != null) {
+                handler.post(() -> player.seekTo(position));
+            }
+        }
+
+        public void stop() {
+            stop(false);
+        }
+
+        public void stop(final boolean ended) {
+            if (plugin != null) plugin.onPlayerEvent("stop", new JSObject().put("ended", ended));
+            releasePlayer();
+            // Do not destroy service here, keep it alive or let it be destroyed by unbind if needed?
+            // Original code destroyed service on stop. But we want it to persist?
+            // If stopped, maybe we can stop foreground?
+            stopForeground(true);
+            // But we don't want to kill the service if the user just pressed stop but might play again?
+            // Actually, if they press stop, the notification goes away.
+            // So stopping foreground is correct.
+        }
+
+        public void releasePlayer() {
+            if (player != null) {
+                handler.post(() -> {
+                    Log.d("RemoteStreamerService", "releasing player");
+                    stopUpdatingTime();
+                    if (player != null) {
+                            player.release();
+                            player = null;
+                    }   
+                    audioManager.abandonAudioFocusRequest(focusRequest);
+                });
+            }
+        }
+
+        private void setupPlayerListeners() {
+            player.addListener(new Player.Listener() {
+                @Override
+                public void onPlaybackStateChanged(int state) {
+                    switch (state) {
+                        case Player.STATE_BUFFERING:
+                            if (plugin != null) plugin.onPlayerEvent("buffering", new JSObject().put("isBuffering", true));
+                            break;
+                        case Player.STATE_READY:
+                            if (plugin != null) plugin.onPlayerEvent("buffering", new JSObject().put("isBuffering", false));
+                            if (!isLiveStream) startUpdatingTime();
+                            break;
+                        case Player.STATE_ENDED:
+                            stopUpdatingTime();
+                            stop(true);
+                            break;
+                    }
+                }
+
+                @Override
+                public void onIsPlayingChanged(boolean isPlaying) {
+                    if (isPlaying) {
+                        if (plugin != null) plugin.onPlayerEvent("play", new JSObject());
+                    } else {
+                        if (plugin != null) plugin.onPlayerEvent("pause", new JSObject());
+                    }
+                }
+
+                @Override
+                public void onPlayerError(PlaybackException error) {
+                    if (error.getCause().getClass().equals(java.net.ConnectException.class)) {
+                        pause();
+                    }
+                    if (error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW) {
+                        player.seekToDefaultPosition();
+                        player.prepare();
+                        player.play();
+                    }
+                    if (plugin != null) plugin.onPlayerEvent("error", new JSObject().put("message", error.getMessage()));
+                }
+            });
+        }
+
+        private void startUpdatingTime() {
+            stopUpdatingTime();
+            updateTimeTask = new Runnable() {
+                @Override
+                public void run() {
+                    if (player != null && player.isPlaying()) {
+                        long currentTime = player.getCurrentPosition();
+                        long duration = player.getDuration();
+                        setDuration(duration);
+                        setPosition(currentTime);
+                        update();
+                        JSObject timeData = new JSObject()
+                                .put("currentTime", currentTime / 1000.0)
+                                .put("duration", duration == C.TIME_UNSET ? 0 : duration / 1000.0);
+                        if (plugin != null) plugin.onPlayerEvent("timeUpdate", timeData);
+                        handler.postDelayed(this, 500);
+                    } else {
+                        handler.postDelayed(this, 1000);
+                    }
+                }
+            };
+            handler.post(updateTimeTask);
+        }
+
+        private void stopUpdatingTime() {
+            if (updateTimeTask != null) {
+                handler.removeCallbacks(updateTimeTask);
+                updateTimeTask = null;
+            }
+        }
+
+        @Override
+        public void onAudioFocusChange(int focusChange) {
+            if (player == null) {
+                return;
+            }
+
+            handler.post(() -> {
+                switch (focusChange) {
+                    case AudioManager.AUDIOFOCUS_GAIN:
+                        player.setVolume(1.0f);
+                        if (resumeOnFocusLossTransient) {
+                            player.play();
+                        }
+                        break;
+                    case AudioManager.AUDIOFOCUS_LOSS:
+                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                        resumeOnFocusLossTransient = player.isPlaying();
+                        player.pause();
+                        break;
+                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                        player.setVolume(0.1f);
+                        break;
+                }
+            });
+        }
+
+        public void setVolume(float volume) {
+            handler.post(() -> {
+                if (player != null) {
+                    player.setVolume(volume);
+                }
+            });
+        }
+
+        public long getCurrentPosition() {
+            return position;
         }
     }


### PR DESCRIPTION
This was my original prompt:
In this Capacitor js project, we are experiencing an issue on Android, where the audio stops playing by it's self after a few minutes when the phone is locked and/or the app is playing in the background. Can you take a hard look at all of the capacitor and android configurations to see if we are covering all the bases for allowing the audio to play  in the background uninterrupted

capacitor v6 docs: https://capacitorjs.com/docs/v6/

this is our custom audio player capacitor plugin we built that we are using that has the solution in for iOS, Android and the web: https://github.com/nypublicradio/capacitor-remote-streamer

this is the plan AI came up with:

Implementation Plan - Fix Android Background Audio
The current implementation of @nypublicradio/capacitor-remote-streamer instantiates and manages the ExoPlayer within the RemoteStreamerPlugin class. This ties the audio player's lifecycle to the Android Activity. When the app is in the background, Android may destroy the Activity to reclaim resources, triggering handleOnDestroy in the plugin, which releases the player and stops the audio.

To fix this, we must move the ExoPlayer instance and playback logic into the RemoteStreamerService. This Service is configured as a Foreground Service, which allows it to run independently of the Activity and persist in the background.

User Review Required
IMPORTANT

Architectural Change: This is a significant refactor of the custom plugin. I will perform this refactor on a local copy of the plugin (e.g., in local_plugins/) and update 
package.json
 to point to it. You will need to eventually merge these changes back into your main plugin repository.

WARNING

Dependency Removal: I recommend removing bp-capacitor-background-mode as it is redundant for the Android audio implementation. However, since you mentioned it might be used by iOS (though my analysis shows the custom plugin doesn't use it directly), we can keep it installed but ensure it doesn't interfere with the Android service. If it's not used by other parts of the app, it should be safe to remove. I will verify if bp-capacitor-background-mode is used elsewhere in the project before removing.

Proposed Changes
1. Local Plugin Setup
Copy node_modules/@nypublicradio/capacitor-remote-streamer to local_plugins/capacitor-remote-streamer.
Update package.json to point to file:local_plugins/capacitor-remote-streamer.
Note: This change will only affect the Android implementation within the plugin. iOS and Web implementations will remain untouched.
2. Refactor RemoteStreamerService.java (Android Only)
Move ExoPlayer: Instantiate ExoPlayer in onCreate (or connectAndInitialize if context is needed, but Service context is preferred).
Implement Playback Methods: Add play, pause, seekTo, stop methods to the Service.
Manage Lifecycle: Ensure ExoPlayer is released only when the Service is destroyed (e.g., onDestroy or explicit stop), not when the Activity unbinds.
Handle Audio Focus: Move AudioManager.OnAudioFocusChangeListener logic to the Service.
3. Refactor RemoteStreamerPlugin.java (Android Only)
Remove Player Logic: Remove ExoPlayer instance and direct playback control.
Proxy Calls: Update play, pause, etc., to call the corresponding methods on the bound service instance.
Remove handleOnDestroy Logic: Do not stop the service or release the player in handleOnDestroy. Only unbind.
4. Configuration Cleanup
Verify if bp-capacitor-background-mode is used in other parts of the app.
If unused, remove bp-capacitor-background-mode from package.json and capacitor.config.ts.
If used, ensure it doesn't conflict (the native foreground service should take precedence for audio).
Verification Plan
Automated Tests
Since this involves native Android code and background behavior, automated unit tests are limited.
We will rely on compilation checks (if possible) and code review.
Manual Verification
Build the App: Run npx cap sync android and build the Android app.
Play Audio: Start playing audio in the app.
Background App: Minimize the app.
Lock Screen: Lock the phone.
Wait: Wait for 10-15 minutes (or simulate low memory to kill Activity).
Verify: Audio should continue playing without interruption.
Controls: Verify lock screen controls (play/pause/next) still work.

What I did:
Instead of copying the audio player plugin into my project, I have cloned it here to work in... and in my parent project, I am pointing to this instance. (    "@nypublicradio/capacitor-remote-streamer": "file:../capacitor-remote-streamer",)

I just needed to paste one catlog error and make one more fix and its now perfect it seems. 